### PR TITLE
firefox compatibility and no data color

### DIFF
--- a/app/Waffle.js
+++ b/app/Waffle.js
@@ -235,7 +235,7 @@ var WaffleVis = function () {
             legend
               .append("text")
               .attr("dx", 40)
-              .attr("alignment-baseline", "hanging")
+              .attr("dominant-baseline", "hanging")
               .text((d, i) => `${d}: ${candidates[i].Votes} (${candidates[i].ratio.toFixed(1)}%)`);
 
             /**

--- a/app/static/js/ChoroplethMain.js
+++ b/app/static/js/ChoroplethMain.js
@@ -99,7 +99,7 @@ var ChoroplethVis = function () {
           if(d.properties.ParentSum >0)
           return colorScale(d.properties.ParentSum);
         else 
-        return 'Red'
+        return 'White'
         })
         .attr("d", geoGenerator)
         .attr("stroke", "black")
@@ -198,7 +198,7 @@ var drawChoroplethLegend = function (colorScale, svg) {
 var DrawCartogram = function () {};
 
 
-function rewind(geo){
+function rewind (geo){
   const fixedGeoJSON = {...geo}
   fixedGeoJSON.features = fixedGeoJSON.features.map(f =>
     turf.rewind(f, { reverse: true })


### PR DESCRIPTION
changed waffle chart style attribute to be compatible with firefox and changed the no data color on the choropleth to white (will probably exclude no data entirely)